### PR TITLE
Add download retry logic, for a total of 4 download attempts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,13 +66,11 @@ async fn main() -> Result<()> {
 				if existing.eq_ignore_ascii_case(&info.hash) {
 					continue;
 				}
-			} else {
-				if exists(&target_file)? {
-					let local_hash = calculate_file_hash(&target_file)?;
-					if local_hash.eq_ignore_ascii_case(&info.hash) {
-						local_cache.insert(info.path.clone(), local_hash);
-						continue;
-					}
+			} else if exists(&target_file)? {
+				let local_hash = calculate_file_hash(&target_file)?;
+				if local_hash.eq_ignore_ascii_case(&info.hash) {
+					local_cache.insert(info.path.clone(), local_hash);
+					continue;
 				}
 			}
 


### PR DESCRIPTION
Upon using this application to download the game files, I found the application failing downloads randomly:
<img width="1292" height="185" alt="image" src="https://github.com/user-attachments/assets/f5688704-7d38-44e2-88a8-9fb966706b38" />

But upon retrying the download, it always succeeds. I have good internet with a wired connection, so this is unexpected. I found myself using a bash script to auto retry upon failure:

```bash
while ! ./enterance; do :; done
```

So I figured I should add retry logic to the application directly. That's what this PR is for.